### PR TITLE
Added option to specify version from questions

### DIFF
--- a/src/crxConverter.ts
+++ b/src/crxConverter.ts
@@ -135,6 +135,10 @@ export function convert(argv: any, src: string, dest: string) {
                 message: "Identity Name:"
             }, {
                 type: "input",
+                name: "appVersion",
+                message: "App Version (default: 1.0.0.0):"
+            }, {
+                type: "input",
                 name: "publisherIdentity",
                 message: "Publisher Identity:"
             }, {
@@ -170,6 +174,7 @@ export function convert(argv: any, src: string, dest: string) {
                     {
                         // appDisplayName: answers.useCurrentName ? w3cManifest.short_name : answers.appDisplayName,
                         identityName: answers.identityName,
+                        appVersion: answers.appVersion || "1.0.0.0",
                         // identityName: answers.identityName || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                         publisherDisplayName: answers.publisherDisplayName,
                         // publisherDisplayName: answers.publisherDisplayName || "AUTHOR_NAME",

--- a/src/webConverter.ts
+++ b/src/webConverter.ts
@@ -16,6 +16,7 @@ var validIconFormats = [
 export interface IAppIdentity {
     appDisplayName?: string;
     identityName: string;
+    appVersion: string;
     publisherIdentity: string;
     publisherDisplayName: string;
 }
@@ -210,7 +211,7 @@ export function w3CToAppxManifest(w3cManifest: IW3CManifest, appxManifestTemplat
     // Update properties
     var appxManifest = appxManifestTemplate
         .replace(/{IdentityName}/g, appIdentity.identityName)
-        .replace(/{Version}/g, "1.0.0.0")
+        .replace(/{Version}/g, appIdentity.appVersion)
         .replace(/{PublisherIdentity}/g, appIdentity.publisherIdentity)
         .replace(/{PhoneProductId}/g, guid)
         .replace(/{AppDisplayName}/g, encodeXML(appIdentity.appDisplayName || w3cManifest.short_name))


### PR DESCRIPTION
If you want to update a .appx file in the Windows Dev Center, you will need to specify another version number. With these changes you should be able to do this from the command line when specifying your app properties. This way you can re-use your Chrome manifest without having to use VS or MakeAppX. 

I couldn't get to compile the TrueScript files from VS so I changed the npm package files manually and was able to update the version number this way. Maybe you can update the npm package to allow this feature.
